### PR TITLE
fix for Xcode 8 and TNS 2.3.0

### DIFF
--- a/i18n.ios.js
+++ b/i18n.ios.js
@@ -2,7 +2,7 @@ require('globals');
 var application = require("application");
 var format = require('format');
 
-var bundle = NSBundle.mainBundle();
+var bundle = NSBundle.mainBundle;
 
 var L = function() {
 	arguments[0] = bundle.localizedStringForKeyValueTable(arguments[0], '', null);


### PR DESCRIPTION
Greetings, after trying to use the module in {N} 2.3 with Angular 2, there was this change that had to be made to get the module implemented. This is due to some breaking changes introduced with the newer versions of XCode and {N}.

I found the solution at this link https://github.com/EddyVerbruggen/nativescript-appversion/issues/6

Kind Regards
