### PR TITLE
Custom lang path

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Assuming you have defined in **strings.xml** the definitions and in the model th
 	<string formatted="false" name="multi_replace">We can replace directly in xml: %s or from the model: %s</string>
 ~~~
 
+Language defaults to english if the phone's language doesn't match any of your defined languages. If you want to set your own default language, add this configuration to your project's package.json
+
+~~~
+"nativescript-i18n": {
+    "defaultLang": "es"
+}
+~~~
+
 ####IMPORTANT !!####
 
 -  for all the strings definitions that have a replacement you need to add `formatted=false`

--- a/demo/package.json
+++ b/demo/package.json
@@ -24,6 +24,7 @@
 		"lazy": "1.0.11"
 	},
 	"nativescript-i18n": {
-		"customLangPath": "app/resources/i18n"
+		"customLangPath": "app/resources/i18n",
+		"defaultLang": "es"
 	}
 }

--- a/lib/before-prepare.js
+++ b/lib/before-prepare.js
@@ -7,13 +7,19 @@ module.exports = function(logger, platformsData, projectData, hookArgs) {
 	var appResourcesDirectoryPath = projectData.appResourcesDirectoryPath;
 	var i18nFolderPath = path.join(projectData.projectDir, 'app', 'i18n');
 	var pjson = require(path.join(projectData.projectDir, 'package.json'));
+	var defaultLang = 'en';
 
-	if (pjson["nativescript-i18n"] && pjson["nativescript-i18n"].customLangPath) {
-		var customLangPath = path.join(projectData.projectDir, pjson["nativescript-i18n"].customLangPath);
-		if (fs.existsSync(customLangPath) ) {
-			i18nFolderPath = customLangPath;
-		}
-	}
+    if (pjson['nativescript-i18n']) {
+        if (pjson['nativescript-i18n'].customLangPath) {
+            var customLangPath = path.join(projectData.projectDir, pjson['nativescript-i18n'].customLangPath);
+            if (fs.existsSync(customLangPath)) {
+                i18nFolderPath = customLangPath;
+            }
+            if (pjson['nativescript-i18n'].defaultLang) {
+                defaultLang = pjson['nativescript-i18n'].defaultLang;
+            }
+        }
+    }
 
 
 	return new Promise(function(resolve, reject) {
@@ -21,7 +27,7 @@ module.exports = function(logger, platformsData, projectData, hookArgs) {
 			if (platform === 'android') {
 				fs.readdirSync(i18nFolderPath).forEach(function(lang) {
 					var outputFile;
-					if (lang === 'en') {
+					if (lang === defaultLang) {
 						outputFile = path.join(appResourcesDirectoryPath, 'Android', 'values', 'strings.xml');
 					} else {
 						outputFile = path.join(appResourcesDirectoryPath, 'Android', 'values-' + lang, 'strings.xml');

--- a/lib/before-prepare.js
+++ b/lib/before-prepare.js
@@ -15,10 +15,10 @@ module.exports = function(logger, platformsData, projectData, hookArgs) {
             if (fs.existsSync(customLangPath)) {
                 i18nFolderPath = customLangPath;
             }
+        }
             if (pjson['nativescript-i18n'].defaultLang) {
                 defaultLang = pjson['nativescript-i18n'].defaultLang;
             }
-        }
     }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-i18n",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "description": "An i18n nativescript plugin using native standards",
   "main": "i18n.js",
   "nativescript": {


### PR DESCRIPTION
This shoul do it - sorry I haven't really worked on open source before, had trouble forcing Webstorm to adhere to your formatting standards (that's why there are so many commits)

On another note - I checked how iOS does it - you need to set CFBundleDevelopmentRegion in your Info.Plist, which seems like out of scope of this plugin, maybe just add the information to readme?