### PR TITLE
webpack --uglify compatibility

### DIFF
--- a/i18n.android.js
+++ b/i18n.android.js
@@ -9,7 +9,7 @@ const resources = context.getResources();
 
 const L = function () {
     if (resources && arguments.length) {
-        let resID = resources.getIdentifier(arguments[0], "string", packageName);
+        var resID = resources.getIdentifier(arguments[0], "string", packageName);
 
         if (resID != 0) {
             arguments[0] = resources.getString(resID);


### PR DESCRIPTION
Without this change errors will be thrown regarding `resID`.

Thanks for considering and keep up the great work!