### PR TITLE
Make language-with-country tags work on Android

### DIFF
--- a/lib/before-prepare.js
+++ b/lib/before-prepare.js
@@ -59,11 +59,14 @@ module.exports = function(logger, platformsData, projectData, hookArgs) {
 						}
 						outputFile = path.join(appResourcesDirectoryPath, 'Android', 'values', 'strings.xml');
 					} else {
-						var androidPath = path.join(appResourcesDirectoryPath, 'Android', 'values-' + lang);
+						// If the language tag has a country code, we need to add an 'r' before it
+						var rlang = lang.replace(/-(?=[A-Z]{2,})/, '-r');
+
+						var androidPath = path.join(appResourcesDirectoryPath, 'Android', 'values-' + rlang);
 						if (!fs.existsSync(androidPath)) {
 							fs.mkdirSync(androidPath);
 						}
-						outputFile = path.join(appResourcesDirectoryPath, 'Android', 'values-' + lang, 'strings.xml');
+						outputFile = path.join(appResourcesDirectoryPath, 'Android', 'values-' + rlang, 'strings.xml');
 					}
 					fs.writeFileSync(outputFile, fs.readFileSync(path.join(i18nFolderPath, lang, 'strings.xml'), 'utf8'));
 				});


### PR DESCRIPTION
Language tags such as `pt-BR` and `en-GB` now work properly on Android by adding an `r` before the country code (`pt-rBR`, `en-rGB`, etc.).