### PR TITLE
Better directory tree and XML base structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,19 @@ npm install --save nativescript-i18n
 Create a folder `i18n` in the `app` folder with the following structure:
 
 ~~~
-App_Resources
-i18n
+app
   |
-  |-- en
-  |		|- strings.xml
+  |-- App_Resources
   |
-  |-- es
-  		|- strings.xml
+[...]
+  |
+  |-- i18n
+       |
+       |-- en
+             |- strings.xml
+       |
+       |-- es
+             |- strings.xml
 ~~~
 
 
@@ -107,6 +112,13 @@ Language defaults to english if the phone's language doesn't match any of your d
 -  for all the strings definitions that have a replacement you need to add `formatted=false`
 -  quotes and apostrophes need to be escaped `<string name="with_quotes">Apostrophe: \' and quotes: \"</string>`
 -  % signs need to be escaped by setting `formatted="false"` and then **doubling them up**: `<string formatted="false" name="percent"> Percent Sign: %%</string>`
+-  We need to use the following format for the strings.xml **otherwise app build will fail**
+
+	~~~
+	<?xml version="1.0" encoding="utf-8"?>
+	<resources>
+	</resources>
+	~~~
 -  We need to add in strings.xml the next two lines for the app to compile properly which **also makes the app name localized on both ios and android and sets the title of the initial activity on android**
 
 	~~~


### PR DESCRIPTION
The `before-prepare.js` hook return a Promise() that search for all files in *i18nFolderPath*:
```
fs.readdirSync(i18nFolderPath).forEach(function(lang)
```
defined as:
```
var i18nFolderPath = path.join(projectData.projectDir, 'app', 'i18n');
```

The README states correctly to create the `i18n` folder in `app` directory but the tree is not well defined: i think that this will help to better understand directory structure.
Also in the custom i18n's directory location it erroneously use `App_Resources/i18n` as the default directory

At the end the few info in IMPORTANT section about the XML format try to avoid common copy/paste errors