### PR TITLE
Allow hook to run in NativeScript 6

### DIFF
--- a/lib/before-prepare.js
+++ b/lib/before-prepare.js
@@ -3,8 +3,18 @@ var path = require('path');
 var parser = require('xmldom').DOMParser;
 var plist = require('plist');
 
-module.exports = function(logger, platformsData, projectData, hookArgs) {
-	var platform = hookArgs.platform.toLowerCase();
+function getPlatformsData($injector) {
+    try {
+        return $injector.resolve("platformsData");
+    } catch (err) {
+        return $injector.resolve("platformsDataService");
+    }
+}
+
+module.exports = function(logger, projectData, injector, hookArgs) {
+	const platformsData = getPlatformsData(injector);
+	var platform = (hookArgs.prepareData && hookArgs.prepareData.platform) || hookArgs.platform;
+	platform = platform.toLowerCase();
 	var appResourcesDirectoryPath = projectData.appResourcesDirectoryPath;
 	var i18nFolderPath = path.join(projectData.projectDir, 'app', 'i18n');
 	var pjson = require(path.join(projectData.projectDir, 'package.json'));


### PR DESCRIPTION
Fix script for NativeScript 6 as https://www.nativescript.org/blog/migrating-cli-hooks-to-nativescript-6.0