### PR TITLE
NS7 style pre/postinstall hooking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nativescript-i18n
+# nativescript-i18n(+NS7 support)
 
 This is a plugin for Nativescript that implements **i18n** in an easy manner.
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "format": "^0.2.2",
     "globals": "^9.17.0",
-    "nativescript-hook": "~0.2.5",
+    "@nativescript/hook": "~2.0.0",
     "plist": "^2.1.0",
     "xmldom": "^0.1.27"
   },

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,1 +1,1 @@
-require('nativescript-hook')(__dirname).postinstall(__dirname);
+require('@nativescript/hook')(__dirname).postinstall();

--- a/preuninstall.js
+++ b/preuninstall.js
@@ -1,1 +1,1 @@
-require('nativescript-hook')(__dirname).preuninstall(__dirname);
+require('@nativescript/hook')(__dirname).preuninstall();


### PR DESCRIPTION
NativeScript 7 needs to use @nativescript/hook instead of nativescript-hook module to hook before-prepare code.
But this PR contains backward compatibility issue. 
Please consider version number is you will merge it (such as 0.4 -> 1.0.0 or 2.0.0)
